### PR TITLE
fixed camera stream access on iOS Safari, see: https://stackoverflow.…

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -478,6 +478,7 @@ async function init(stream) {
   videoStream = stream;
 
   videoElement = document.createElement('video');
+  videoElement.setAttribute('playsinline', '');
   videoElement.id = webgazer.params.videoElementId;
   videoElement.srcObject = stream;
   videoElement.autoplay = true;


### PR DESCRIPTION
…com/questions/53483975/navigator-mediadevices-getusermedia-not-working-on-ios-12-safari (#186)

Co-authored-by: Kelvin Homann <khomann@frobese.de>